### PR TITLE
Add a missing 'on' in the Workflow section of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ As a reference, the basic steps for working with GitHub Flow are as follows:
   * Fork the _upstream_ repository to your GitHub (the _origin_).
   * [Clone] the _origin_ repository to your local machine.
   * Set the  _upstream_ remote for your local repository to point to the _upstream_ repository.
-  * Create a _feature branch_ from the _main_ branch your local machine.
+  * Create a _feature branch_ from the _main_ branch on your local machine.
   * Make the edits to the documentation or the code in your _feature branch_.
   * Commit your edits.
     * If the contribution reflects the work of multiple people, ensure that everyone receives attribution by [Creating a commit with multiple authors].


### PR DESCRIPTION
In the CONTRIBUTING.md file of this repository, there is a minor wording issue in the "Workflow" section. In the 5th bullet point, the text currently reads "Create a feature branch from the main branch your local machine." The word "on" is missing in this sentence between "branch" and "your," which affects the clarity of the instruction.

"Fixes #30"