### PR TITLE
Fixed NaN in Seeding Report

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -513,7 +513,7 @@
                     let tableData = this.tableRows
                     let totalTraySeeds = 0
                     tableData.map(h =>
-                       totalTraySeeds = totalTraySeeds + ((parseFloat(h.data[7])==NaN)? 0: (parseFloat(h.data[7])))
+                       totalTraySeeds = totalTraySeeds + (isNaN(parseFloat(h.data[7]))? 0: (parseFloat(h.data[7])))
                     )
                     return totalTraySeeds
                 },

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -513,7 +513,7 @@
                     let tableData = this.tableRows
                     let totalTraySeeds = 0
                     tableData.map(h =>
-                       totalTraySeeds = totalTraySeeds + parseFloat(h.data[7])
+                       totalTraySeeds = totalTraySeeds + ((parseFloat(h.data[7])==NaN)? 0: (parseFloat(h.data[7])))
                     )
                     return totalTraySeeds
                 },


### PR DESCRIPTION
__Pull Request Description__

I fixed the NaN issue in Seeding Report by implementing a validation check for NaN values. Fixes #78  

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
