### PR TITLE
Changed the text 'the Dickinson College Farm' into a link to the farm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you are unfamiliar with [Zulip](https://zulip.com/) it is a group chat applic
 
 ### History ###
 
-FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integration of _two_ related projects FarmData and AnimalData. These projects were conceived and built by Tim Wahls, Matt Steiman and many students to support operation of the [Dickinson College Farm](https://not.the.right.link1).  The FarmData2 project was initiated as a part of curricular redesign in the Computer Science Department at Dickinson College.  It is now an active part of several courses in the curriculum.  It provides students in these courses with early and sustained opportunities to learn and practice modern software development within the context of an open source software community.
+FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integration of _two_ related projects FarmData and AnimalData. These projects were conceived and built by Tim Wahls, Matt Steiman and many students to support operation of the [Dickinson College Farm](https://www.dickinson.edu/farm).  The FarmData2 project was initiated as a part of curricular redesign in the Computer Science Department at Dickinson College.  It is now an active part of several courses in the curriculum.  It provides students in these courses with early and sustained opportunities to learn and practice modern software development within the context of an open source software community.
 
 ### Acknowledgements ###
 


### PR DESCRIPTION
__Pull Request Description__

Fixing Issue #36: Updated "the Dickinson College Farm" link in the History section.

In the History section of the README.md file, I replaced the text "the Dickinson College Farm" with a link to the [Dickinson College Farm](https://www.dickinson.edu/farm) website. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.

Closes #36
